### PR TITLE
Fix: Match output size when writing frames

### DIFF
--- a/inputs/scripts/zoom_composite.py
+++ b/inputs/scripts/zoom_composite.py
@@ -125,7 +125,7 @@ try:
 
             glReadPixels(0, 0, video_size[0], video_size[1], GL_RGBA, GL_UNSIGNED_BYTE, frame_pixels)
             np_frame = np.array(frame_pixels).reshape(video_size[1], video_size[0], 4)
-            result.write(np_frame)
+            result.write(np_frame[:,:,:3])
 
             pygame.display.flip()
             for e in pygame.event.get():


### PR DESCRIPTION
On Ubuntu 22.04/ Anaconda - does not write any frames out.

Fix: Match output size when writing frames and discard alpha channel.